### PR TITLE
No registration setting

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -204,7 +204,13 @@ function auth0_login_auth0_user($userInfo, $idToken) {
     }
     else {
       // If we are here, we need to create the user.
-      $uid = auth0_create_user_from_auth0($userInfo);
+      // Check drupal settings to see if new users are allowed to register.
+      if (variable_get('user_register', USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL) == USER_REGISTER_ADMINISTRATORS_ONLY) {
+        return drupal_set_message(t('Only site administrators can create new user accounts.'), 'error');
+      }
+      else {
+        $uid = auth0_create_user_from_auth0($userInfo);
+      }
     }
 
     auth0_insert_auth0_user($userInfo, $uid);
@@ -275,9 +281,14 @@ function auth0_create_user_from_auth0($userInfo) {
   }
   $user->name = $username;
   $user->is_new = TRUE;
-  $user->status = 1;
+  $user->status = variable_get('user_register', USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL) == USER_REGISTER_VISITORS;
   $user->pass = user_password();
   $new_user = user_save($user);
+
+  // Notify the user if they must have approval.
+  if (!$user->status) {
+    drupal_set_message(t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.<br />In the meantime, a welcome message with further instructions has been sent to your e-mail address.'));
+  }
 
   return $new_user->uid;
 }

--- a/auth0.module
+++ b/auth0.module
@@ -287,7 +287,7 @@ function auth0_create_user_from_auth0($userInfo) {
 
   // Notify the user if they must have approval.
   if (!$user->status) {
-    drupal_set_message(t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.<br />In the meantime, a welcome message with further instructions has been sent to your e-mail address.'));
+    drupal_set_message(t('Thank you for applying for an account. Your account is currently pending approval by the site administrator.'));
   }
 
   return $new_user->uid;


### PR DESCRIPTION
The current code allows new user registrations even if the core setting prohibits it. This was enough to cause a 'less critical' SA for another 3rd party auth module recently (https://www.drupal.org/node/2511410) so it should probably be fixed here too.