### PR TITLE
Drupal registrations

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -352,23 +352,10 @@ function auth0_advanced_form($form, &$form_state) {
   );
 
   $form['auth0_allow_signup'] = array(
-    '#type' => 'radios',
-    '#title' => t('Allow new users to sign up'),
-    '#default_value' => variable_get('auth0_allow_signup', ''),
-    '#options' => array(
-      '' => t('No new user registrations'),
-      'auth0' => t('New user registrations in Auth0'),
-      'drupal' => t('New user registrations in Drupal')
-    ),
-    '' => array(
-      '#description' => t('Remove the registration form altogether. New users may still be created automatically for social or enterprise logins if the <a href="@url">site user settings</a> allow visitors to create accounts.', array('@url' => 'admin/config/people/accounts')),
-    ),
-    'auth0' => array(
-      '#description' => t('If you have database connection in Auth0 you can allow users to signup using the Auth0 widget.'),
-    ),
-    'drupal' => array(
-      '#description' => t('Allow users to register for Drupal accounts. This works best if you have a custom database connection in Auth0 that can authenticate against your Drupal user database.'),
-    )
+    '#type' => 'checkbox',
+    '#title' => t('Allow user signup'),
+    '#default_value' => variable_get('auth0_allow_signup', TRUE),
+    '#description' => t('If you have database connection you can allow users to signup using the Auth0 widget.'),
   );
 
 
@@ -538,7 +525,7 @@ function auth0_enabled($operation = '') {
 
     // See if our settings allow us to override the registration form.
     if ($operation == 'signup' || $operation == 'reset') {
-      $out = variable_get('auth0_allow_signup', '') == 'auth0';
+      $out = (bool)variable_get('auth0_allow_signup', '');
     }
   }
 

--- a/auth0.module
+++ b/auth0.module
@@ -425,20 +425,20 @@ function auth0_user_logout($account) {
  * Replace the user login forms with the Auth0 login widget.
  */
 function auth0_form_alter(&$form, $form_state, $form_id) {
-  if ($form_id == 'user_login_block' || $form_id == 'user_login') {
+  if ($form_id == 'user_login_block' || $form_id == 'user_login' && auth0_enabled('login')) {
     _auth0_form_replace_with_lock($form, 'signin');
   }
 
   // If Auth0 controls the user database.
-  if (variable_get('auth0_allow_signup', '') == 'auth0') {
-    if ($form_id == 'user_register_form') {
-      _auth0_form_replace_with_lock($form, 'signup');
-    }
-    if ($form_id == 'user_pass') {
-      _auth0_form_replace_with_lock($form, 'reset');
-    }
+  if ($form_id == 'user_register_form' && auth0_enabled('signup')) {
+    _auth0_form_replace_with_lock($form, 'signup');
   }
-  else if (variable_get('auth0_allow_signup', '') == '') {
+  if ($form_id == 'user_pass' && auth0_enabled('reset')) {
+    _auth0_form_replace_with_lock($form, 'reset');
+  }
+  
+  // If the settings say to remove the signup altogether.
+  if (!variable_get('auth0_allow_signup', '')) {
     if ($form_id == 'user_register_form' || $form_id == 'user_pass') {
       // @TODO: Remove the user signup option.
       drupal_goto('user/login');
@@ -483,15 +483,11 @@ function template_preprocess_auth0_lock(&$vars) {
     'rememberLastLogin' => $vars['sso_enabled'],
     'mode' => $vars['mode'],
   );
-  if (variable_get('auth0_allow_signup', '') == 'auth0') {
-    $vars['params']['disableSignupAction'] = FALSE;
-    $vars['params']['disableResetAction'] = FALSE;
+  if (auth0_enabled('signup')) {
+    $vars['params']['disableSignupAction'] = FALSE;    
   }
-  else if (variable_get('auth0_allow_signup', '') == 'drupal') {
-    $vars['params']['disableSignupAction'] = FALSE;
-    $vars['params']['disableResetAction'] = FALSE;
-    $vars['params']['signupLink'] = url('user/register');
-    $vars['params']['resetLink'] = url('user/password');
+  if (auth0_enabled('reset')) {
+    $vars['params']['disableResetAction'] = FALSE;    
   }
 
   // Generate a link to a login form to be displayed as a no-js fallback.
@@ -521,4 +517,33 @@ function template_preprocess_auth0_lock(&$vars) {
 
   // Add the Drupal behavior to initialize the widget.
   drupal_add_js(drupal_get_path('module', 'auth0') . '/auth0.lock.js');
+}
+
+
+/**
+ * Determine if Auth0 is enabled and can be used.
+ */
+function auth0_enabled($operation = '') {
+  $out = FALSE;
+
+  // Check that the module has been configured.
+  if (
+    variable_get("auth0_domain", '') &&
+    variable_get("auth0_client_id", '') &&
+    variable_get('auth0_client_secret', '')
+    ) {
+
+    // Default to on if the module is configured.
+    $out = TRUE;
+
+    // See if our settings allow us to override the registration form.
+    if ($operation == 'signup' || $operation == 'reset') {
+      $out = variable_get('auth0_allow_signup', '') == 'auth0';
+    }
+  }
+
+  // Allow other modules to override the status.
+  drupal_alter('auth0_enabled', $out, $operation);
+
+  return $out;
 }

--- a/auth0.module
+++ b/auth0.module
@@ -352,11 +352,25 @@ function auth0_advanced_form($form, &$form_state) {
   );
 
   $form['auth0_allow_signup'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow user signup'),
-    '#default_value' => variable_get('auth0_allow_signup', TRUE),
-    '#description' => t('If you have database connection you can allow users to signup using the Auth0 widget.'),
+    '#type' => 'radios',
+    '#title' => t('Allow new users to sign up'),
+    '#default_value' => variable_get('auth0_allow_signup', ''),
+    '#options' => array(
+      '' => t('No new user registrations'),
+      'auth0' => t('New user registrations in Auth0'),
+      'drupal' => t('New user registrations in Drupal')
+    ),
+    '' => array(
+      '#description' => t('Remove the registration form altogether. New users may still be created automatically for social or enterprise logins if the <a href="@url">site user settings</a> allow visitors to create accounts.', array('@url' => 'admin/config/people/accounts')),
+    ),
+    'auth0' => array(
+      '#description' => t('If you have database connection in Auth0 you can allow users to signup using the Auth0 widget.'),
+    ),
+    'drupal' => array(
+      '#description' => t('Allow users to register for Drupal accounts. This works best if you have a custom database connection in Auth0 that can authenticate against your Drupal user database.'),
+    )
   );
+
 
   $form['auth0_widget_cdn'] = array(
     '#type' => 'textfield',
@@ -414,11 +428,21 @@ function auth0_form_alter(&$form, $form_state, $form_id) {
   if ($form_id == 'user_login_block' || $form_id == 'user_login') {
     _auth0_form_replace_with_lock($form, 'signin');
   }
-  else if ($form_id == 'user_register_form') {
-    _auth0_form_replace_with_lock($form, 'signup');
+
+  // If Auth0 controls the user database.
+  if (variable_get('auth0_allow_signup', '') == 'auth0') {
+    if ($form_id == 'user_register_form') {
+      _auth0_form_replace_with_lock($form, 'signup');
+    }
+    if ($form_id == 'user_pass') {
+      _auth0_form_replace_with_lock($form, 'reset');
+    }
   }
-  else if ($form_id == 'user_pass') {
-    _auth0_form_replace_with_lock($form, 'reset');
+  else if (variable_get('auth0_allow_signup', '') == '') {
+    if ($form_id == 'user_register_form' || $form_id == 'user_pass') {
+      // @TODO: Remove the user signup option.
+      drupal_goto('user/login');
+    }
   }
 }
 
@@ -452,12 +476,23 @@ function template_preprocess_auth0_lock(&$vars) {
     'authParams' => array(
       'state' => drupal_get_token('auth0_state'),
     ),
-    'disableSignupAction' => !variable_get("auth0_allow_signup", TRUE),
+    'disableSignupAction' => TRUE,
+    'disableResetAction' => TRUE,
     'container' => 'auth0-login-form',
     'sso' => $vars['sso_enabled'],
     'rememberLastLogin' => $vars['sso_enabled'],
     'mode' => $vars['mode'],
   );
+  if (variable_get('auth0_allow_signup', '') == 'auth0') {
+    $vars['params']['disableSignupAction'] = FALSE;
+    $vars['params']['disableResetAction'] = FALSE;
+  }
+  else if (variable_get('auth0_allow_signup', '') == 'drupal') {
+    $vars['params']['disableSignupAction'] = FALSE;
+    $vars['params']['disableResetAction'] = FALSE;
+    $vars['params']['signupLink'] = url('user/register');
+    $vars['params']['resetLink'] = url('user/password');
+  }
 
   // Generate a link to a login form to be displayed as a no-js fallback.
   $query = array(


### PR DESCRIPTION
These modifications allow another module to re-enable Drupal registrations without increasing the complexity of the Auth0 base module. Here is a proof of concept reference of how you would enable override this behavior:

    <?php

    function auth0_override_form_auth0_advanced_form_alter(&$form, $form_state) {
      $form['auth0_allow_signup'] = array(
        '#type' => 'radios',
        '#title' => t('Allow new users to sign up'),
        '#default_value' => variable_get('auth0_allow_signup', ''),
        '#options' => array(
          '' => t('No new user registrations'),
          'auth0' => t('New user registrations in Auth0'),
          'drupal' => t('New user registrations in Drupal')
        ),
        '' => array(
          '#description' => t('Remove the registration form altogether. New users may still be created automatically for social or enterprise logins if the <a href="@url">site user settings</a> allow visitors to create accounts.', array('@url' => 'admin/config/people/accounts')),
        ),
        'auth0' => array(
          '#description' => t('If you have database connection in Auth0 you can allow users to signup using the Auth0 widget.'),
        ),
        'drupal' => array(
          '#description' => t('Allow users to register for Drupal accounts. This works best if you have a custom database connection in Auth0 that can authenticate against your Drupal user database.'),
        )
      );
    }


    function auth0_override_auth0_enabled_alter(&$status, $operation) {
      if ($operation == 'signup' || $operation == 'reset') {
        $status = $status && (variable_get('auth0_allow_signup', '') == 'auth0');
      }
    }
