### PR TITLE
Fixes PHP notice for unlinked accounts

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -302,9 +302,12 @@ function auth0_find_auth0_user($id) {
  */
 function auth0_get_auth0_object_from_drupal_uid($uid) {
   $rs = db_select('auth0_user', 'a')->fields('a')->condition('drupal_id', $uid, '=')->execute()->fetch();
-  $rs = drupal_unpack($rs, 'auth0_object');
-  unset($rs->auth0_object);
-  return $rs;
+  if (!empty($rs)) {
+    $rs = drupal_unpack($rs, 'auth0_object');
+    unset($rs->auth0_object);
+    return $rs;
+  }
+  return FALSE;
 }
 
 


### PR DESCRIPTION
This fixes a PHP notice ('try to get property of non-object in drupal_unpack()') when attempting to load Drupal user that is not linked with an Auth0 account.

The error can be reproduced by viewing the Auth0 tab for a user account that has not been linked with an Auth0 account.
