### PR TITLE
Add a drupal_alter call to auth0 lock configuration

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -607,6 +607,8 @@ function template_preprocess_auth0_lock(&$vars) {
     $vars['params']['disableResetAction'] = FALSE;    
   }
 
+  drupal_alter('auth0_params', $vars['params']);
+
   // Generate a link to a login form to be displayed as a no-js fallback.
   $query = array(
     'redirect_uri' => $vars['params']['callbackURL'], 


### PR DESCRIPTION
Adds a drupal_alter call to allow other modules to modify lock parameters before using them to generate the fallback link and the widget.