### PR TITLE
Change CDN call for lock-7.min.js to https 

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -1,7 +1,7 @@
 <?php
 
 // Define some module default settings
-define('AUTH0_WIDGET_CDN', 'http://cdn.auth0.com/js/lock-7.min.js');
+define('AUTH0_WIDGET_CDN', 'https://cdn.auth0.com/js/lock-7.min.js');
 define('AUTH_LOGIN_CSS', "#a0-widget .a0-panel {
     min-width: 90%;
     padding: 5%;


### PR DESCRIPTION
On sites that are not mixed mode, and only accept HTTPS, the module fails to appear correctly.