### PR TITLE
Allow for logout url returnTo to be App or Account level

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -1,7 +1,7 @@
 <?php
 
 // Define some module default settings
-define('AUTH0_WIDGET_CDN', 'http://cdn.auth0.com/js/lock-7.min.js');
+define('AUTH0_WIDGET_CDN', 'https://cdn.auth0.com/js/lock-7.min.js');
 define('AUTH_LOGIN_CSS', "#a0-widget .a0-panel {
     min-width: 90%;
     padding: 5%;

--- a/auth0.module
+++ b/auth0.module
@@ -479,6 +479,13 @@ function auth0_advanced_settings_form($form, &$form_state) {
     '#default_value' => variable_get('auth0_login_css', AUTH_LOGIN_CSS),
     '#description' => t('This CSS controls the widget look and feel.'),
   );
+// Add option to have the logout url at the application level or account level
+  $form['auth0_returnTo_account'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use returnTo URLs at the App Level'),
+    '#default_value' => variable_get('auth0_returnTo_app', FALSE),
+    '#description' => t('Check this box to use the <a href="@url">returnTo URLs</a> at the Account Level', array('@url' => 'https://auth0.com/docs/logout#redirecting-users-after-logout')),
+  );
 
   return system_settings_form($form);
 }
@@ -494,8 +501,13 @@ function auth0_user_logout($account) {
     session_destroy();
 
     $domain = check_plain(variable_get("auth0_domain", ''));
-
-    drupal_goto("https://$domain/v2/logout?returnTo=" . urlencode(url('<front>', array('absolute' => TRUE))));
+    
+    if(variable_get("auth0_returnTo_app",FALSE)) {
+      $client = check_plain(variable_get("auth0_client_id", ''));
+      drupal_goto("https://$domain/v2/logout?returnTo=" . urlencode(url('<front>', array('absolute' => TRUE))) . "&client_id=$client");
+    } else {
+      drupal_goto("https://$domain/v2/logout?returnTo=" . urlencode(url('<front>', array('absolute' => TRUE))));
+    }
   }
 }
 


### PR DESCRIPTION
See Issue #28 

This adds an advanced setting to allow for the returnTo URL to have a client_id param appended if the setting is true.

It is false by default, so the current behavior will not change.