### PR TITLE
Rename package name to work with Drupal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "auth0/drupal",
+    "name": "drupal/auth0",
     "require": {
         "auth0/auth0-php": "0.6.*",
         "adoy/oauth2": "dev-master",


### PR DESCRIPTION
Addresses the package name problem described in #36.