### PR TITLE
Namespace Exceptions being caught to global

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -68,7 +68,7 @@ class AuthController extends ControllerBase {
     try {
         $userInfo = $auth0->getUserInfo();
         $idToken = $auth0->getIdToken();
-    } catch(Exception $e) {
+    } catch(\Exception $e) {
 
     }
 
@@ -247,7 +247,7 @@ class AuthController extends ControllerBase {
     catch(\UnexpectedValueException $e) {
        drupal_set_message(t('Your session has expired.'),'error');
     }
-    catch(Exception $e) {
+    catch(\Exception $e) {
        drupal_set_message(t('Sorry, we couldnt send the email'),'error');
     }
 


### PR DESCRIPTION
Problem: this controller is catching a class that doesn't exist: `Drupal\auth0\Controller\Exception`

Solution: namespace the `Exception` class to the global namespace, i.e. catch PHP exceptions.