### PR TITLE
Assign properties correctly in events

### DIFF
--- a/src/Event/Auth0UserSigninEvent.php
+++ b/src/Event/Auth0UserSigninEvent.php
@@ -4,14 +4,15 @@ namespace Drupal\auth0\Event;
 use Symfony\Component\EventDispatcher\Event;
 
 class Auth0UserSigninEvent extends Event {
-  
+
   const NAME = 'auth0.signin';
 
   protected $user;
   protected $auth0Profile;
 
-  public function __construct($user, $auth0Profile) {
+  public function __construct($user, $auth0_profile) {
     $this->user = $user;
+    $this->auth0Profile = $auth0_profile;
   }
 
   public function getUser() {
@@ -21,4 +22,5 @@ class Auth0UserSigninEvent extends Event {
   public function getAuth0Profile() {
     return $this->auth0Profile;
   }
+
 }

--- a/src/Event/Auth0UserSignupEvent.php
+++ b/src/Event/Auth0UserSignupEvent.php
@@ -4,14 +4,15 @@ namespace Drupal\auth0\Event;
 use Symfony\Component\EventDispatcher\Event;
 
 class Auth0UserSignupEvent extends Event {
-  
+
   const NAME = 'auth0.signup';
 
   protected $user;
   protected $auth0Profile;
 
-  public function __construct($user, $auth0Profile) {
+  public function __construct($user, $auth0_profile) {
     $this->user = $user;
+    $this->auth0Profile = $auth0_profile;
   }
 
   public function getUser() {
@@ -21,4 +22,5 @@ class Auth0UserSignupEvent extends Event {
   public function getAuth0Profile() {
     return $this->auth0Profile;
   }
+
 }


### PR DESCRIPTION
The $auth0Profile property wasn't assigned correctly in the event.

This PR resolves that by assigning it in the constructor.