### PR TITLE
Allow signin/signup event subscribers to retrieve Auth0 profile data

### DIFF
--- a/src/Event/Auth0UserSigninEvent.php
+++ b/src/Event/Auth0UserSigninEvent.php
@@ -18,6 +18,7 @@ class Auth0UserSigninEvent extends Event {
    */
   public function __construct($user, $auth0Profile) {
     $this->user = $user;
+    $this->auth0Profile = $auth0Profile;
   }
 
   /**

--- a/src/Event/Auth0UserSignupEvent.php
+++ b/src/Event/Auth0UserSignupEvent.php
@@ -18,6 +18,7 @@ class Auth0UserSignupEvent extends Event {
    */
   public function __construct($user, $auth0Profile) {
     $this->user = $user;
+    $this->auth0Profile = $auth0Profile;
   }
 
   /**


### PR DESCRIPTION
Fixes a small bug where event subscribers are unable to retrieve auth0 profile data on sign-in or sign-up.