### PR TITLE
Add codeclimate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Drupal8 Plugin for Auth0
 ====
 
+[![Code Climate](https://codeclimate.com/github/auth0/auth0-drupal/badges/gpa.svg)](https://codeclimate.com/github/auth0/auth0-drupal)
+
 Single Sign On for Enterprises + Social Login + User/Passwords. For all your Drupal instances. Powered by Auth0.
 
 Demo: <http://auth0-drupal.azurewebsites.net>


### PR DESCRIPTION
This adds the code climate badge to the README. I noticed a few of the recent PRs that were merged decreased the amount of code that complies with Drupal coding standards.

It may be worth enabling the webhook to be able to see the impact to code style per pull request. Instructions are here: https://docs.codeclimate.com/docs/github#section-pull-requests

And here are two screenshots of an example configuration:

![screenshot from 2016-12-20 14-01-53](https://cloud.githubusercontent.com/assets/778111/21365940/331d7c94-c6bd-11e6-86bb-53903aca4e07.png)

![screenshot from 2016-12-20 14-02-12](https://cloud.githubusercontent.com/assets/778111/21365944/3830b66a-c6bd-11e6-911d-5d3dd75eac13.png)
