### PR TITLE
Proposal: Add Auth0 JWT authentication provider

### DIFF
--- a/auth0.routing.yml
+++ b/auth0.routing.yml
@@ -18,6 +18,13 @@ auth0.legacy_login:
   options:
     _maintenance_access: TRUE
 
+auth0.get_jwt:
+  path: '/user/jwt'
+  defaults:
+    _controller: '\Drupal\auth0\Controller\AuthController::getToken'
+  requirements:
+    _user_is_logged_in: 'TRUE'
+
 auth0.callback:
   path: '/auth0/callback'
   defaults:

--- a/auth0.services.yml
+++ b/auth0.services.yml
@@ -1,0 +1,6 @@
+services:
+  authentication.auth0:
+    class: Drupal\auth0\Authentication\Provider\Auth0JWTAuthenticationProvider
+    arguments: ['@config.factory', '@entity_type.manager']
+    tags:
+      - { name: authentication_provider, provider_id: auth0_jwt }

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,7 @@
     "license": "MIT",
     "description": "Single Sign On for Enterprises + Social Login + User/Passwords. For all your Drupal instances. Powered by Auth0.",
     "require": {
-        "auth0/auth0-php": "~4.0",
-        "adoy/oauth2": "dev-master",
-        "firebase/php-jwt" : "dev-master"
+        "auth0/auth0-php": "~4.0"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "description": "Single Sign On for Enterprises + Social Login + User/Passwords. For all your Drupal instances. Powered by Auth0.",
     "require": {
-        "auth0/auth0-php": "0.6.*",
+        "auth0/auth0-php": "~4.0",
         "adoy/oauth2": "dev-master",
         "firebase/php-jwt" : "dev-master"
     },

--- a/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
+++ b/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\auth0\Authentication\Provider;
+
+use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\JWTVerifier;
+use Drupal\Core\Authentication\AuthenticationProviderInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+
+/**
+ * Class Auth0JWTAuthenticationProvider.
+ *
+ * @package Drupal\auth0\Authentication\Provider
+ */
+class Auth0JWTAuthenticationProvider implements AuthenticationProviderInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a HTTP basic authentication provider object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Checks whether suitable authentication credentials are on the request.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request object.
+   *
+   * @return bool
+   *   TRUE if authentication credentials suitable for this provider are on the
+   *   request, FALSE otherwise.
+   */
+  public function applies(Request $request) {
+    return !empty($request->headers->get('authorization'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authenticate(Request $request) {
+    $authHeader = $request->headers->get('authorization');
+    $config = $this->configFactory->get('auth0.settings');
+    $token = trim(str_replace('Bearer ', '', $authHeader));
+
+    $secret = $config->get('auth0_client_secret');
+    $client_id = $config->get('auth0_client_id');
+
+    $decoded_token = null;
+    try {
+      $verifier = new JWTVerifier([
+        'valid_audiences' => [$client_id],
+        'client_secret' => $secret,
+        'secret_base64_encoded' => FALSE,
+      ]);
+
+      $decoded_token = $verifier->verifyAndDecode($token);
+    }
+    catch (CoreException $e) {
+      throw new AccessDeniedHttpException($e->getMessage());
+    }
+
+    return $this->entityTypeManager->getStorage('user')->load($decoded_token->uid);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function cleanup(Request $request) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function handleException(GetResponseForExceptionEvent $event) {
+    $exception = $event->getException();
+    if ($exception instanceof AccessDeniedHttpException) {
+      $event->setException(
+        new UnauthorizedHttpException('Invalid consumer origin.', $exception)
+      );
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+}

--- a/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
+++ b/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
@@ -59,7 +59,8 @@ class Auth0JWTAuthenticationProvider implements AuthenticationProviderInterface 
    *   request, FALSE otherwise.
    */
   public function applies(Request $request) {
-    return !empty($request->headers->get('authorization'));
+    $authHeader = $request->headers->get('authorization');
+    return !empty($authHeader) && strpos($authHeader, 'Bearer') === 0;
   }
 
   /**

--- a/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
+++ b/src/Authentication/Provider/Auth0JWTAuthenticationProvider.php
@@ -4,6 +4,7 @@ namespace Drupal\auth0\Authentication\Provider;
 
 use Auth0\SDK\Exception\CoreException;
 use Auth0\SDK\JWTVerifier;
+use Drupal\auth0\Authentication\DrupalCacheProvider;
 use Drupal\Core\Authentication\AuthenticationProviderInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -77,7 +78,6 @@ class Auth0JWTAuthenticationProvider implements AuthenticationProviderInterface 
       $verifier = new JWTVerifier([
         'valid_audiences' => [$client_id],
         'client_secret' => $secret,
-        'secret_base64_encoded' => FALSE,
       ]);
 
       $decoded_token = $verifier->verifyAndDecode($token);
@@ -86,7 +86,7 @@ class Auth0JWTAuthenticationProvider implements AuthenticationProviderInterface 
       throw new AccessDeniedHttpException($e->getMessage());
     }
 
-    return $this->entityTypeManager->getStorage('user')->load($decoded_token->uid);
+    return $this->entityTypeManager->getStorage('user')->load($decoded_token->scopes->uid);
   }
 
   /**

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -18,7 +18,7 @@ use Drupal\auth0\Event\Auth0UserSignupEvent;
 use Drupal\auth0\Exception\EmailNotSetException;
 use Drupal\auth0\Exception\EmailNotVerifiedException;
 
-use Auth0SDK\Auth0;
+use Auth0\SDK\Auth0;
 
 /**
  * Controller routines for auth0 authentication.
@@ -98,7 +98,7 @@ class AuthController extends ControllerBase {
     $userInfo = NULL;
 
     try {
-      $userInfo = $auth0->getUserInfo();
+      $userInfo = $auth0->getUser();
       $idToken = $auth0->getIdToken();
     }
     catch (\Exception $e) {

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -2,9 +2,11 @@
 
 namespace Drupal\auth0\Controller;
 
+use Auth0\SDK\API\Helpers\TokenGenerator;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Url;
 use Drupal\user\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
@@ -58,6 +60,23 @@ class AuthController extends ControllerBase {
       '#callbackURL' => "$base_root/auth0/callback",
     );
 
+  }
+
+  /**
+   * Handles the callback for the current user's JWT token.
+   */
+  public function getToken() {
+    $user = \Drupal::currentUser();
+    $config = \Drupal::service('config.factory')->get('auth0.settings');
+
+    $generator = new TokenGenerator([
+      'client_id' => $config->get('auth0_client_id'),
+      'client_secret' => $config->get('auth0_client_secret'),
+    ]);
+
+    return new JsonResponse($generator->generate([
+      'uid' => $user->getAccount()->id(),
+    ]));
   }
 
   /**


### PR DESCRIPTION
I'm looking at a use-case where I'd like to allow users to make RESTful web service calls against API endpoints on a Drupal 8 site using JWTs signed using the client id/secret details already used/provided by this module.  This would be as an alternative to Drupal 8's built-in Basic Auth and Cookie auth providers.

For some relevant Drupal 8 documentation, see [authentication API overview](https://www.drupal.org/docs/8/api/authentication-api/overview) and the [RESTful web services API overview](https://www.drupal.org/docs/8/api/restful-web-services-api/restful-web-services-api-overview).

Would the module maintainers be amenable to this feature?

### Proposed usage

Authenticated users could retrieve their JWT via a web service endpoint at `/user/jwt`.  The token is generated using the `TokenGenerator` helper provided by the Auth0 SDK. At a minimum, the Drupal user ID would be included in the payload for authentication:

```json
{
  "scopes": {
    "uid": "{DRUPAL_USER_ID}"
  }
}
```

Module developers and site builders could choose to configure their REST resources to use Auth0 JWT as a supported authentication provider like this (also available as an authentication provider via [REST UI](https://www.drupal.org/project/restui))

`rest.settings.yml` would look something like this:
```yml
resources:
  entity:node:
    GET:
      supported_formats:
        - json
      supported_auth:
        - auth0_jwt
```

Users would make requests using these tokens in the manner described in the standard:

```
GET /node/123 HTTP/1.1
Host: example.com
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ
```

### Todo:
- [ ] Consider adding CSRF protection on the `/user/jwt` endpoint via `_csrf_request_header_token` route requirement.