### PR TITLE
Fixed the missing username claim config.

### DIFF
--- a/src/Form/BasicAdvancedForm.php
+++ b/src/Form/BasicAdvancedForm.php
@@ -74,10 +74,11 @@ Drupal user account.
 ')
     );
 
+    $username_claim = $config->get('auth0_username_claim');
     $form['auth0_username_claim'] = array(
       '#type' => 'textfield',
       '#title' => t('Map Auth0 claim to Drupal user name.'),
-      '#default_value' => $config->get('auth0_username_claim', 'nickname'),
+      '#default_value' => empty($username_claim) ? 'nickname' : $username_claim,
       '#description' => t('Maps the given claim field as the Drupal user name field. The default is the nickname claim'),
     );
     
@@ -176,6 +177,7 @@ Drupal roles not listed above will not be changed by this module.
             ->set('auth0_claim_mapping', $form_state->getValue('auth0_claim_mapping'))
             ->set('auth0_claim_to_use_for_role', $form_state->getValue('auth0_claim_to_use_for_role'))
             ->set('auth0_role_mapping', $form_state->getValue('auth0_role_mapping'))
+            ->set('auth0_username_claim', $form_state->getValue('auth0_username_claim'))
             ->save();
   }
 


### PR DESCRIPTION
Login was failing because of blank `username_claim` and throwing an error
```
Drupal\Core\Database\InvalidQueryException: Query condition 'users_field_data.name IN ()' cannot be empty. in Drupal\Core\Database\Query\Condition->condition() (line 103 of /drupal/web/core/lib/Drupal/Core/Database/Query/Condition.php).
```
This was because `$config->get('auth0_username_claim', 'nickname')` does not return default value like varibale_get() of Drupal 7. 
