### PR TITLE
Fixed login for new tenants

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -4,7 +4,9 @@
  * Module definition
  */
 
+define( 'AUTH0_DEFAULT_SCOPES', 'openid email profile' );
 define( 'AUTH0_DEFAULT_SIGNING_ALGORITHM', 'RS256' );
+define( 'AUTH0_DEFAULT_USERNAME_CLAIM', 'nickname' );
 
 /**
  * Replace a form with the lock widget.
@@ -23,6 +25,7 @@ function auth0_theme() {
         'loginCSS' => NULL,
         'callbackURL' => NULL,
         'lockExtraSettings' => '{}',
+        'scopes' => AUTH0_DEFAULT_SCOPES,
       ),
     ),
   );

--- a/auth0.module
+++ b/auth0.module
@@ -4,9 +4,8 @@
  * Module definition
  */
 
-use Drupal\auth0\Util;
+define( 'AUTH0_DEFAULT_SIGNING_ALGORITHM', 'RS256' );
 
- 
 /**
  * Replace a form with the lock widget.
  */
@@ -30,7 +29,7 @@ function auth0_theme() {
 }
 
 /**
- * Handle users deletion, it shoudl delete the auth0 profile.
+ * Handle users deletion, it should delete the Auth0 profile.
  */
 function auth0_user_delete($account) {
   db_delete('auth0_user')

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -193,7 +193,7 @@ class AuthController extends ControllerBase {
     $connection = null;
     $state = $this->getNonce($returnTo);
     $additional_params = [];
-    $additional_params['scope'] = 'openid profile email nickname';
+    $additional_params['scope'] = 'openid email email_verified profile nickname name';
     if ($this->offlineAccess) $additional_params['scope'] .= ' offline_access';
     if ($prompt) $additional_params['prompt'] = $prompt;
 
@@ -416,7 +416,10 @@ class AuthController extends ControllerBase {
     if ($user_name_claim == '') {
       $user_name_claim = 'nickname';
     }
-    $user_name_used = ! empty( $userInfo[$user_name_claim] ) ? $userInfo[$user_name_claim] : $userInfo['sub'];
+    $user_name_used = ! empty( $userInfo[ $user_name_claim ] )
+      ? $userInfo[ $user_name_claim ] :
+      // Drupal usernames do not allow pipe characters
+      str_replace( '|', '_', $userInfo['sub'] );
     
     if ($config->get('auth0_join_user_by_mail_enabled')) {
       \Drupal::logger('auth0')->notice($userInfo['email'] . 'join user by mail is enabled, looking up user by email');

--- a/src/Form/BasicAdvancedForm.php
+++ b/src/Form/BasicAdvancedForm.php
@@ -85,7 +85,7 @@ Drupal user account.
     $form['auth0_username_claim'] = array(
       '#type' => 'textfield',
       '#title' => t('Map Auth0 claim to Drupal user name.'),
-      '#default_value' => empty($username_claim) ? 'nickname' : $username_claim,
+      '#default_value' => ! empty( $username_claim ) ? $username_claim : AUTH0_DEFAULT_USERNAME_CLAIM,
       '#description' => t('Maps the given claim field as the Drupal user name field. The default is the nickname claim'),
     );
     

--- a/src/Form/BasicSettingsForm.php
+++ b/src/Form/BasicSettingsForm.php
@@ -61,7 +61,7 @@ class BasicSettingsForm extends FormBase {
         'HS256' => $this->t('HS256'),
         'RS256' => $this->t('RS256'),
       ],
-      '#default_value' => $config->get('auth0_jwt_signature_alg', 'HS256'),
+      '#default_value' => $config->get('auth0_jwt_signature_alg', AUTH0_DEFAULT_SIGNING_ALGORITHM),
       '#description' => t('Your JWT Signing Algorithm for the ID token.  RS256 is recommended, but must be set in the advanced settings under oauth for this client.'),
       '#required' => TRUE,
     );

--- a/src/Form/BasicSettingsForm.php
+++ b/src/Form/BasicSettingsForm.php
@@ -61,7 +61,9 @@ class BasicSettingsForm extends FormBase {
         'HS256' => $this->t('HS256'),
         'RS256' => $this->t('RS256'),
       ],
-      '#default_value' => $config->get('auth0_jwt_signature_alg', AUTH0_DEFAULT_SIGNING_ALGORITHM),
+      '#default_value' => $config->get('auth0_jwt_signature_alg')
+        ? $config->get('auth0_jwt_signature_alg')
+        : AUTH0_DEFAULT_SIGNING_ALGORITHM,
       '#description' => t('Your JWT Signing Algorithm for the ID token.  RS256 is recommended, but must be set in the advanced settings under oauth for this client.'),
       '#required' => TRUE,
     );

--- a/src/Form/BasicSettingsForm.php
+++ b/src/Form/BasicSettingsForm.php
@@ -7,6 +7,7 @@ namespace Drupal\auth0\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\auth0\Util\AuthHelper;
 
 /**
  * This forms handles the basic module configurations.
@@ -54,7 +55,7 @@ class BasicSettingsForm extends FormBase {
       '#description' => t('Your Auth0 domain, you can see it in the auth0 dashboard.'),
       '#required' => TRUE,
     );
-    $form[AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM] = array(
+    $form[ AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM ] = array(
       '#type' => 'select',
       '#title' => t('JWT Signature Algorithm'),
       '#options' => [

--- a/src/Form/BasicSettingsForm.php
+++ b/src/Form/BasicSettingsForm.php
@@ -54,17 +54,17 @@ class BasicSettingsForm extends FormBase {
       '#description' => t('Your Auth0 domain, you can see it in the auth0 dashboard.'),
       '#required' => TRUE,
     );
-    $form['auth0_jwt_signature_alg'] = array(
+    $form[AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM] = array(
       '#type' => 'select',
       '#title' => t('JWT Signature Algorithm'),
       '#options' => [
         'HS256' => $this->t('HS256'),
         'RS256' => $this->t('RS256'),
       ],
-      '#default_value' => $config->get('auth0_jwt_signature_alg')
-        ? $config->get('auth0_jwt_signature_alg')
+      '#default_value' => $config->get( AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM )
+        ? $config->get( AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM )
         : AUTH0_DEFAULT_SIGNING_ALGORITHM,
-      '#description' => t('Your JWT Signing Algorithm for the ID token.  RS256 is recommended, but must be set in the advanced settings under oauth for this client.'),
+      '#description' => t('Your JWT Signing Algorithm for the ID token. RS256 is recommended and must be set in the advanced settings for this client under the OAuth tab.'),
       '#required' => TRUE,
     );
 
@@ -94,8 +94,8 @@ class BasicSettingsForm extends FormBase {
       $form_state->setErrorByName('auth0_domain', $this->t('Please complete your Auth0 domain'));
     }
 
-    if (empty($form_state->getValue('auth0_jwt_signature_alg'))) {
-      $form_state->setErrorByName('auth0_jwt_signature_alg', $this->t('Please complete your Auth0 Signature Algorithm'));
+    if (empty($form_state->getValue(AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM))) {
+      $form_state->setErrorByName(AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM, $this->t('Please complete your Auth0 Signature Algorithm'));
     }
   }
 
@@ -108,7 +108,7 @@ class BasicSettingsForm extends FormBase {
     $config->set('auth0_client_id', $form_state->getValue('auth0_client_id'))
             ->set('auth0_client_secret', $form_state->getValue('auth0_client_secret'))
             ->set('auth0_domain', $form_state->getValue('auth0_domain'))
-            ->set('auth0_jwt_signature_alg', $form_state->getValue('auth0_jwt_signature_alg'))
+            ->set(AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM, $form_state->getValue(AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM))
             ->set('auth0_secret_base64_encoded', $form_state->getValue('auth0_secret_base64_encoded'))
             ->save();
   }

--- a/src/Util/AuthHelper.php
+++ b/src/Util/AuthHelper.php
@@ -79,10 +79,11 @@ class AuthHelper {
    *
    * @param string $idToken - the ID token to validate
    *
-   * @return object
+   * @return mixed
    *
    * @throws CoreException
    * @throws InvalidTokenException
+   * @throws \Exception
    */
   public function validateIdToken($idToken) {
     $auth0_domain = 'https://' . $this->domain . '/';

--- a/src/Util/AuthHelper.php
+++ b/src/Util/AuthHelper.php
@@ -8,6 +8,8 @@ namespace Drupal\auth0\Util;
 
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\API\Authentication;
+use Auth0\SDK\Exception\CoreException;
+use Auth0\SDK\Exception\InvalidTokenException;
 
 /**
  * Controller routines for auth0 authentication.
@@ -41,7 +43,10 @@ class AuthHelper {
     $this->client_id = $this->config->get(AuthHelper::AUTH0_CLIENT_ID);
     $this->client_secret = $this->config->get(AuthHelper::AUTH0_CLIENT_SECRET);
     $this->redirect_for_sso = $this->config->get(AuthHelper::AUTH0_REDIRECT_FOR_SSO);
-    $this->auth0_jwt_signature_alg = $this->config->get(AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM);
+    $this->auth0_jwt_signature_alg = $this->config->get(
+      AuthHelper::AUTH0_JWT_SIGNING_ALGORITHM,
+      AUTH0_DEFAULT_SIGNING_ALGORITHM
+    );
     $this->secret_base64_encoded = FALSE || $this->config->get(AuthHelper::AUTH0_SECRET_ENCODED);
   }
 
@@ -71,14 +76,15 @@ class AuthHelper {
 
   /**
    * Validate the ID token
-   * @param $idToken the ID token to validate
-   * @return user an array of named claims from the ID token
-   * @throws invalid token exception if the token is invalid, otherwise returns user
+   *
+   * @param string $idToken - the ID token to validate
+   *
+   * @return object
+   *
+   * @throws CoreException
+   * @throws InvalidTokenException
    */
   public function validateIdToken($idToken) {
-    /**
-     * Validate the ID Token
-     */
     $auth0_domain = 'https://' . $this->domain . '/';
     $auth0_settings = array();
     $auth0_settings['authorized_iss'] = [$auth0_domain];

--- a/templates/auth0-login.html.twig
+++ b/templates/auth0-login.html.twig
@@ -11,7 +11,7 @@
     lock_options.auth.redirectUrl = lock_options.auth.redirectUrl || '{{callbackURL}}';
     lock_options.auth.responseType = lock_options.auth.responseType || 'code';
     lock_options.auth.params = lock_options.auth.params || {};
-    lock_options.auth.params.scope = lock_options.auth.params.scope || 'openid email email_verified profile nickname name';
+    lock_options.auth.params.scope = lock_options.auth.params.scope || '{{scopes}}';
     lock_options.auth.params.state = '{{state}}';
 
     if ('{{ offlineAccess }}' === 'TRUE') {

--- a/templates/auth0-login.html.twig
+++ b/templates/auth0-login.html.twig
@@ -11,7 +11,7 @@
     lock_options.auth.redirectUrl = lock_options.auth.redirectUrl || '{{callbackURL}}';
     lock_options.auth.responseType = lock_options.auth.responseType || 'code';
     lock_options.auth.params = lock_options.auth.params || {};
-    lock_options.auth.params.scope = lock_options.auth.params.scope || 'openid email nickname';
+    lock_options.auth.params.scope = lock_options.auth.params.scope || 'openid email email_verified nickname';
     lock_options.auth.params.state = '{{state}}';
 
     if ('{{ offlineAccess }}' === 'TRUE') {

--- a/templates/auth0-login.html.twig
+++ b/templates/auth0-login.html.twig
@@ -11,7 +11,7 @@
     lock_options.auth.redirectUrl = lock_options.auth.redirectUrl || '{{callbackURL}}';
     lock_options.auth.responseType = lock_options.auth.responseType || 'code';
     lock_options.auth.params = lock_options.auth.params || {};
-    lock_options.auth.params.scope = lock_options.auth.params.scope || 'openid email email_verified nickname';
+    lock_options.auth.params.scope = lock_options.auth.params.scope || 'openid email email_verified profile nickname name';
     lock_options.auth.params.state = '{{state}}';
 
     if ('{{ offlineAccess }}' === 'TRUE') {


### PR DESCRIPTION
* adjusted for $userinfo arrays that do not have a provided nickname
* replaced `identities` check with provider check on `user_id`
* added `email_verified` to ID token scope
* changed default signing algorithm to RS256 for new installs
* docblocks

Waiting on #87 