### PR TITLE
Added configuration for a main tenant connection

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -285,7 +285,6 @@ class AuthController extends ControllerBase {
             'state' => $this->getNonce($returnTo),
             'scopes' => AUTH0_DEFAULT_SCOPES,
             'offlineAccess' => $this->offlineAccess,
-            'tenantConnection' => $this->config->get('auth0_tenant_connection'),
             'formTitle' => $this->config->get('auth0_form_title'),
             'jsonErrorMsg' => $this->t('There was an error parsing the "Lock extra settings" field.'),
           ],
@@ -373,6 +372,10 @@ class AuthController extends ControllerBase {
 
     if ($this->tenantConnection) {
       $additional_params['connection'] = $this->config->get('auth0_tenant_connection');
+    }
+
+    if ($this->config->get('auth0_allow_signup')) {
+      $additional_params['display'] = 'sup';
     }
 
     if ($prompt) {

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -61,6 +61,7 @@ class AuthController extends ControllerBase {
   const AUTH0_JWT_SIGNING_ALGORITHM = 'auth0_jwt_signature_alg';
   const AUTH0_SECRET_ENCODED = 'auth0_secret_base64_encoded';
   const AUTH0_OFFLINE_ACCESS = 'auth0_allow_offline_access';
+  const AUTH0_TENANT_CONNECTION = 'auth0_tenant_connection';
 
   protected $eventDispatcher;
   protected $tempStore;
@@ -128,6 +129,13 @@ class AuthController extends ControllerBase {
    * @var bool|null
    */
   protected $offlineAccess;
+
+  /**
+   * If we want to authorize agains the main tenant specified here.
+   *
+   * @var string
+   */
+  protected $tenantConnection;
 
   /**
    * The Auth0 helper.
@@ -205,6 +213,7 @@ class AuthController extends ControllerBase {
     $this->auth0JwtSignatureAlg = $this->config->get(AuthController::AUTH0_JWT_SIGNING_ALGORITHM);
     $this->secretBase64Encoded = FALSE || $this->config->get(AuthController::AUTH0_SECRET_ENCODED);
     $this->offlineAccess = FALSE || $this->config->get(AuthController::AUTH0_OFFLINE_ACCESS);
+    $this->tenantConnection = FALSE || $this->config->get(AuthController::AUTH0_TENANT_CONNECTION);
     $this->httpClient = $http_client;
     $this->auth0 = FALSE;
   }
@@ -276,6 +285,7 @@ class AuthController extends ControllerBase {
             'state' => $this->getNonce($returnTo),
             'scopes' => AUTH0_DEFAULT_SCOPES,
             'offlineAccess' => $this->offlineAccess,
+            'tenantConnection' => $this->config->get('auth0_tenant_connection'),
             'formTitle' => $this->config->get('auth0_form_title'),
             'jsonErrorMsg' => $this->t('There was an error parsing the "Lock extra settings" field.'),
           ],
@@ -359,6 +369,10 @@ class AuthController extends ControllerBase {
 
     if ($this->offlineAccess) {
       $additional_params['scope'] .= ' offline_access';
+    }
+
+    if ($this->tenantConnection) {
+      $additional_params['connection'] = $this->config->get('auth0_tenant_connection');
     }
 
     if ($prompt) {

--- a/src/Form/BasicAdvancedForm.php
+++ b/src/Form/BasicAdvancedForm.php
@@ -40,7 +40,7 @@ class BasicAdvancedForm extends FormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Tenant connection'),
       '#default_value' => $config->get('auth0_tenant_connection') ?: $this->t(''),
-      '#description' => $this->t('This is the other tenant that you want to authenticate against, e.g. main-tenant-oidc. Please activate Redirect Login for SSO for that use case.'),
+      '#description' => $this->t('This is the other tenant that you want to authenticate against, e.g. main-tenant-oidc. Since the parameter is added to the authorize URL it can only be used together with active SSO.'),
     ];
 
     $form['auth0_allow_signup'] = [

--- a/src/Form/BasicAdvancedForm.php
+++ b/src/Form/BasicAdvancedForm.php
@@ -36,6 +36,13 @@ class BasicAdvancedForm extends FormBase {
       '#description' => $this->t('This is the title for the login widget.'),
     ];
 
+    $form['auth0_tenant_connection'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Tenant connection'),
+      '#default_value' => $config->get('auth0_tenant_connection') ?: $this->t(''),
+      '#description' => $this->t('This is the other tenant that you want to authenticate against, e.g. main-tenant-oidc.'),
+    ];
+
     $form['auth0_allow_signup'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Allow user signup'),
@@ -191,7 +198,7 @@ Drupal roles not listed above will not be changed by this module.
       ->set('auth0_claim_mapping', $form_state->getValue('auth0_claim_mapping'))
       ->set('auth0_claim_to_use_for_role', $form_state->getValue('auth0_claim_to_use_for_role'))
       ->set('auth0_role_mapping', $form_state->getValue('auth0_role_mapping'))
-      ->set('auth0_username_claim', $form_state->getValue('auth0_username_claim'))
+      ->set('auth0_tenant_connection', $form_state->getValue('auth0_tenant_connection'))
       ->save();
   }
 

--- a/src/Form/BasicAdvancedForm.php
+++ b/src/Form/BasicAdvancedForm.php
@@ -40,7 +40,7 @@ class BasicAdvancedForm extends FormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Tenant connection'),
       '#default_value' => $config->get('auth0_tenant_connection') ?: $this->t(''),
-      '#description' => $this->t('This is the other tenant that you want to authenticate against, e.g. main-tenant-oidc.'),
+      '#description' => $this->t('This is the other tenant that you want to authenticate against, e.g. main-tenant-oidc. Please activate Redirect Login for SSO for that use case.'),
     ];
 
     $form['auth0_allow_signup'] = [

--- a/src/Util/AuthHelper.php
+++ b/src/Util/AuthHelper.php
@@ -24,6 +24,7 @@ class AuthHelper {
   const AUTH0_JWT_SIGNING_ALGORITHM = 'auth0_jwt_signature_alg';
   const AUTH0_SECRET_ENCODED = 'auth0_secret_base64_encoded';
   const AUTH0_OFFLINE_ACCESS = 'auth0_allow_offline_access';
+  const AUTH0_TENANT_CONNECTION = 'auth0_tenant_connection';
 
   private $logger;
   private $config;


### PR DESCRIPTION
### Changes

- Added the needed functionality to support our main-tenant federation in SSO mode
- This is a "works for me" PR - hopefully this somehow fits into your development.
- This only works in SSO mode since I was unable to figure out the needed changes for the lock.js.

### References

- https://github.com/auth0/auth0-drupal/issues/119

Please note any links that are not publicly accessible.

### Testing

You need a main-child tenant setup in Auth0. The desired Authorize URL in our case contains "connection=main-tenant-oidc" to directly login with the centrally hosted login page. Furthermore the trigger to show the "register" tab is activated by supplying "display=sub" as additional parameter.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)