### PR TITLE
Send correct telemetry for Drupal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,3 +26,9 @@ Please describe how this can be tested by reviewers. Be specific about anything 
 
 * [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 * [ ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
+* [ ] I ran the PHPCS Drupal coding standards:
+
+```bash
+# Ran from the Drupal root
+$ vendor/bin/phpcs modules/auth0/src --standard=Drupal
+```

--- a/auth0.module
+++ b/auth0.module
@@ -8,6 +8,7 @@
 define('AUTH0_DEFAULT_SCOPES', 'openid email profile');
 define('AUTH0_DEFAULT_SIGNING_ALGORITHM', 'RS256');
 define('AUTH0_DEFAULT_USERNAME_CLAIM', 'nickname');
+define('AUTH0_MODULE_VERSION', '8.x-2.2');
 
 /**
  * Replace a form with the lock widget.

--- a/src/Util/AuthHelper.php
+++ b/src/Util/AuthHelper.php
@@ -73,8 +73,9 @@ class AuthHelper {
    * @return array
    *   A user array of named claims from the ID token.
    *
-   * @throws \Drupal\auth0\Exception\RefreshTokenFailedException
-   *   The token failure exception.
+   * @throws RefreshTokenFailedException
+   * @throws CoreException
+   * @throws InvalidTokenException
    */
   public function getUserUsingRefreshToken($refreshToken) {
     global $base_root;
@@ -122,7 +123,7 @@ class AuthHelper {
   }
 
   /**
-   *
+   * Extend Auth0 PHP SDK telemetry to report for Drupal.
    */
   public static function setTelemetry() {
     $oldInfoHeaders = ApiClient::getInfoHeadersData();

--- a/src/Util/AuthHelper.php
+++ b/src/Util/AuthHelper.php
@@ -9,6 +9,9 @@ namespace Drupal\auth0\Util;
 
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\API\Authentication;
+use Auth0\SDK\API\Helpers\ApiClient;
+use Auth0\SDK\API\Helpers\InformationHeaders;
+
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 
@@ -57,6 +60,8 @@ class AuthHelper {
       AUTH0_DEFAULT_SIGNING_ALGORITHM
     );
     $this->secretBase64Encoded = FALSE || $this->config->get(AuthHelper::AUTH0_SECRET_ENCODED);
+
+    self::setTelemetry();
   }
 
   /**
@@ -114,6 +119,19 @@ class AuthHelper {
     $auth0_settings['secret_base64_encoded'] = $this->secretBase64Encoded;
     $jwt_verifier = new JWTVerifier($auth0_settings);
     return $jwt_verifier->verifyAndDecode($idToken);
+  }
+
+  /**
+   *
+   */
+  public static function setTelemetry() {
+    $oldInfoHeaders = ApiClient::getInfoHeadersData();
+    if ($oldInfoHeaders) {
+      $infoHeaders = InformationHeaders::Extend($oldInfoHeaders);
+      $infoHeaders->setEnvironment('drupal', \Drupal::VERSION);
+      $infoHeaders->setPackage('auth0-drupal', AUTH0_MODULE_VERSION);
+      ApiClient::setInfoHeadersData($infoHeaders);
+    }
   }
 
 }


### PR DESCRIPTION
### Changes

This PR extends the Auth0 PHP SDK telemetry to report correctly for Drupal applications. 

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)