### PR TITLE
add/port prelogin event

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use Drupal\auth0\Event\Auth0UserSigninEvent;
 use Drupal\auth0\Event\Auth0UserSignupEvent;
+use Drupal\auth0\Event\Auth0UserPreLoginEvent;
 use Drupal\auth0\Exception\EmailNotSetException;
 use Drupal\auth0\Exception\EmailNotVerifiedException;
 use Drupal\Core\PageCache\ResponsePolicyInterface;
@@ -530,6 +531,9 @@ class AuthController extends ControllerBase {
    */
   protected function processUserLogin(Request $request, array $userInfo, $idToken, $refreshToken, $expiresAt, $returnTo) {
     $this->auth0Logger->notice('process user login');
+
+    $event = new Auth0UserPreLoginEvent($userInfo);
+    $this->eventDispatcher->dispatch(Auth0UserPreLoginEvent::NAME, $event);
 
     try {
       $this->validateUserEmail($userInfo);

--- a/src/Event/Auth0UserPreLoginEvent.php
+++ b/src/Event/Auth0UserPreLoginEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\auth0\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * User prelogin event.
+ */
+class Auth0UserPreLoginEvent extends Event {
+
+  /**
+   * The event name.
+   */
+  const NAME = 'auth0.prelogin';
+
+  /**
+   * The Auth0 profile.
+   *
+   * @var array
+   */
+  protected $auth0Profile;
+
+  /**
+   * Initialize the event.
+   *
+   * @param array $auth0Profile
+   *   The Auth0 profile array.
+   */
+  public function __construct(array $auth0Profile) {
+    $this->auth0Profile = $auth0Profile;
+  }
+
+  /**
+   * Get the Auth0 profile.
+   *
+   * @return array
+   *   The Auth0 profile.
+   */
+  public function getAuth0Profile() {
+    return $this->auth0Profile;
+  }
+
+}


### PR DESCRIPTION
### Problem

Would be nice to have a prelogin event so we can use Auth0 for SSO and still maintain some level of authorization on a per site basis. And not auto create user accounts across all the sites in the network of auth0 sites.

### Changes

Added a new event called `Auth0UserPreLoginEvent` and dispatch it on top of `processUserLogin` fuction.

### References

In drupal 7 module this was done by a prelogin hook.

### Testing

[Subsriber to event.](https://www.drupal.org/docs/8/creating-custom-modules/event-systems-overview-how-to-subscribe-to-and-dispatch-events)
