### PR TITLE
Fix redirectTo URL parameter

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -415,6 +415,7 @@ class AuthController extends ControllerBase {
       'client_id'     => $this->clientId,
       'client_secret' => $this->clientSecret,
       'redirect_uri'  => "$base_root/auth0/callback",
+      'persist_user' => FALSE,
     ]);
 
     $userInfo = NULL;

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -244,10 +244,7 @@ class AuthController extends ControllerBase {
       $lockExtraSettings = "{}";
     }
 
-    $returnTo = $request->request->get('returnTo', NULL);
-    if (!$returnTo) {
-      $returnTo = $request->query->get('returnTo', NULL);
-    }
+    $returnTo = $request->request->get('returnTo', $request->query->get('returnTo', NULL));
 
     // If supporting SSO, redirect to the hosted login page for authorization.
     if ($this->redirectForSso) {

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -288,13 +288,16 @@ class AuthController extends ControllerBase {
    *   The response after logout.
    */
   public function logout() {
+    $auth0Api = new Authentication($this->domain, $this->clientId);
+
     user_logout();
 
-    // Redirect to Auth0 to log out.
-    $auth0Api = new Authentication($this->domain, $this->clientId);
-    $frontPageUrl = Url::fromRoute('<front>', [], ['absolute' => TRUE]);
-    $logoutUrl = $auth0Api->get_logout_link($frontPageUrl, $this->clientId);
-    return new TrustedRedirectResponse($logoutUrl);
+    // If we are using SSO, we need to logout completely from Auth0,
+    // otherwise they will just logout of their client.
+    return new TrustedRedirectResponse($auth0Api->get_logout_link(
+      \Drupal::request()->getSchemeAndHttpHost(),
+      $this->redirectForSso ? NULL : $this->clientId
+    ) );
   }
 
   /**


### PR DESCRIPTION
### Changes

- Fix `returnTo` URL parameter on login URL not redirecting after successful callback processing
- Remove `prompt=none` when redirecting for SSO
- Fix Auth0 logout URL not using Application-level redirects

### References

Closes #136 

### Testing

1) Go to the Drupal login link with a `returnTo` URL parameter set to a site URL.
2) Log in successfully.
3) Final page should be what `returnTo` was set to.

### Checklist

* [x] I ran the PHPCS Drupal coding standards:
