### PR TITLE
#154 - avoid PHP notices on user field mapping

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -659,7 +659,7 @@ class AuthController extends ControllerBase {
       // there is a user to join with. The isDatabase is because we don't want
       // to allow database user creation if there is an existing one with no
       // verified email.
-      if ($userInfo['email_verified'] || $isDatabaseUser) {
+      if (isset($userInfo['email_verified']) || $isDatabaseUser) {
         $joinUser = user_load_by_mail($userInfo['email']);
       }
     }
@@ -795,7 +795,7 @@ class AuthController extends ControllerBase {
       ];
 
       foreach ($mappings as $mapping) {
-        $this->auth0Logger->notice('mapping ' . $mapping);
+        $this->auth0Logger->notice('mapping ' . $mapping[1]);
 
         $key = $mapping[1];
         if (in_array($key, $skip_mappings)) {


### PR DESCRIPTION
### Changes

Fixed some PHP notices when mapping Auth0 claim to Drupal user fields.

`Notice: Array to string conversion in Drupal\auth0\Controller\AuthController->auth0UpdateFields() (line 798 of modules/contrib/auth0/src/Controller/AuthController.php).`

`Notice: Undefined index: email_verified in Drupal\auth0\Controller\AuthController->signupUser() (line 662 of modules/contrib/auth0/src/Controller/AuthController.php).
`
### References

Issue #154 

### Testing

go to /admin/config/auth0/advanced
configure some mappings in the "Mapping of Claims to Profile Fields (one per line):" field
like: 
```
given_name|field_first_name
family_name|field_last_name
```
then log in to the site with a new user - you should have no PHP notices showing up anymore

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] I ran the PHPCS Drupal coding standards:

```bash
# Ran from the Drupal root
$ vendor/bin/phpcs modules/auth0/src --standard=Drupal
```
