### PR TITLE
Remove resend verfication email button

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -705,17 +705,8 @@ class AuthController extends ControllerBase {
    *   The redirect response.
    */
   protected function auth0FailWithVerifyEmail($idToken) {
-
-    $messageHtml = sprintf('
-      <p>%s.</p>
-      <form name="auth0VerifyEmail" action="%s">
-        <input type="hidden" value="%s" name="idToken" />
-        <input type="submit" value="%s" class="button" />
-      </form>',
-      $this->t('Please verify your email and log in again'),
-      Url::fromRoute('auth0.verify_email', [], [])->toString(),
-      $idToken,
-      $this->t('Resend verification')
+    $messageHtml = sprintf('<p>%s.</p>',
+      $this->t('Please verify your email and log in again')
     );
 
     return $this->failLogin(Markup::create($messageHtml), 'Email not verified');

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -1029,6 +1029,8 @@ class AuthController extends ControllerBase {
    *
    * @throws \Auth0\SDK\Exception\CoreException
    *   Exception thrown when validating email.
+   * 
+   * @deprecated v8.x-2.4 - the legacy send_verification_email endpoint itself is being deprecated and should no longer be called.
    */
   // phpcs:ignore
   public function verify_email(Request $request) {


### PR DESCRIPTION
### Changes

This change removes the "resend email verification" button, as it relates to
a deprecated API endpoint.

### References

Raised through internal discussion and service desk ticket.


### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] I ran the PHPCS Drupal coding standards:

```bash
# Ran from the Drupal root
$ vendor/bin/phpcs modules/auth0/src --standard=Drupal
```
