### PR TITLE
Release v8.x-2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,75 @@
 # Change Log
 
+## [8.x-2.4](https://github.com/auth0/auth0-drupal/tree/8.x-2.4) (2020-07-02)
+
+[Full Changelog](https://github.com/auth0/auth0-drupal/compare/8.x-2.3...8.x-2.4)
+
+**Changed**
+
+- Remove resend verfication email button from the email verification template [\#160](https://github.com/auth0/auth0-drupal/pull/160) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [8.x-2.3](https://github.com/auth0/auth0-drupal/tree/8.x-2.3) (2019-07-01)
+
 [Full Changelog](https://github.com/auth0/auth0-drupal/compare/8.x-2.2...8.x-2.3)
 
 **Closed issues**
+
 - Drupal Profile and Auth0 metadata sync [\#146](https://github.com/auth0/auth0-drupal/issues/146)
 - "Please verify your email" message is shown as HTML code [\#145](https://github.com/auth0/auth0-drupal/issues/145)
 - Vendor directory included in drupal 8 distribution [\#143](https://github.com/auth0/auth0-drupal/issues/143)
 
 **Fixed**
+
 - Fix verify email form output and remove JS [\#147](https://github.com/auth0/auth0-drupal/pull/147) ([joshcanhelp](https://github.com/joshcanhelp))
 - Fix: changes in roles are now detected correctly [\#144](https://github.com/auth0/auth0-drupal/pull/144) ([Phillywonka](https://github.com/Phillywonka))
 - Make sessions persist to fix invalid state [\#140](https://github.com/auth0/auth0-drupal/pull/140) ([bkildow](https://github.com/bkildow))
 
 ## [8.x-2.2](https://github.com/auth0/auth0-drupal/tree/8.x-2.2) (2019-05-10)
+
 [Full Changelog](https://github.com/auth0/auth0-drupal/compare/8.x-2.1...8.x-2.2)
 
 **Closed issues**
+
 - Failed to exchange code for tokens: Invalid state [\#139](https://github.com/auth0/auth0-drupal/issues/139)
 - Issue with returnTo/state post callback [\#136](https://github.com/auth0/auth0-drupal/issues/136)
 - Invalid token [\#130](https://github.com/auth0/auth0-drupal/issues/130)
-- drupal jwt  [\#128](https://github.com/auth0/auth0-drupal/issues/128)
+- drupal jwt [\#128](https://github.com/auth0/auth0-drupal/issues/128)
 - Resend verification link leads to blank page [\#126](https://github.com/auth0/auth0-drupal/issues/126)
 - How to set user roles based on app_metadata? [\#123](https://github.com/auth0/auth0-drupal/issues/123)
 - What happens if exception happens in Drupal? [\#118](https://github.com/auth0/auth0-drupal/issues/118)
 - Fix settings form pages [\#93](https://github.com/auth0/auth0-drupal/issues/93)
 
 **Added**
+
 - add/port prelogin event [\#132](https://github.com/auth0/auth0-drupal/pull/132) ([edysmp](https://github.com/edysmp))
 - Send correct telemetry for Drupal [\#131](https://github.com/auth0/auth0-drupal/pull/131) ([joshcanhelp](https://github.com/joshcanhelp))
 - Add custom domain setting and add new callback error checking [\#125](https://github.com/auth0/auth0-drupal/pull/125) ([identitysolutions](https://github.com/identitysolutions))
 
 **Changed**
+
 - Settings page cleanup [\#138](https://github.com/auth0/auth0-drupal/pull/138) ([joshcanhelp](https://github.com/joshcanhelp))
 
 **Fixed**
+
 - Fix redirectTo URL parameter [\#137](https://github.com/auth0/auth0-drupal/pull/137) ([joshcanhelp](https://github.com/joshcanhelp))
 - Fix inline JavaScript causing resend link not to work [\#129](https://github.com/auth0/auth0-drupal/pull/129) ([joshcanhelp](https://github.com/joshcanhelp))
 - De-Duped EmailNotVerifiedException in AuthController::processUserLogin [\#117](https://github.com/auth0/auth0-drupal/pull/117) ([mptap](https://github.com/mptap))
 
 ## [8.x-2.1](https://github.com/auth0/auth0-drupal/tree/8.x-2.1) (2018-09-28)
+
 [Full Changelog](https://github.com/auth0/auth0-drupal/compare/2.0.3...8.x-2.1)
 
 **Closed issues**
+
 - Drupal.org module [\#86](https://github.com/auth0/auth0-drupal/issues/86)
 
 **Changed**
+
 - Update README, remove README.txt, add GH templates [\#112](https://github.com/auth0/auth0-drupal/pull/112) ([joshcanhelp](https://github.com/joshcanhelp))
 - Drupal standards scan and external file for Lock JS [\#109](https://github.com/auth0/auth0-drupal/pull/109) ([rob3000](https://github.com/rob3000))
 
 **Fixed**
+
 - Fix "array to string conversion" PHP notices [\#115](https://github.com/auth0/auth0-drupal/pull/115) ([hawkeyetwolf](https://github.com/hawkeyetwolf))
 - Fix JSON parsing, role mapping, field mapping, and allow signup [\#113](https://github.com/auth0/auth0-drupal/pull/113) ([joshcanhelp](https://github.com/joshcanhelp))
 - PHPCS of AuthHelper [\#105](https://github.com/auth0/auth0-drupal/pull/105) ([rob3000](https://github.com/rob3000))

--- a/auth0.module
+++ b/auth0.module
@@ -8,7 +8,7 @@
 define('AUTH0_DEFAULT_SCOPES', 'openid email profile');
 define('AUTH0_DEFAULT_SIGNING_ALGORITHM', 'RS256');
 define('AUTH0_DEFAULT_USERNAME_CLAIM', 'nickname');
-define('AUTH0_MODULE_VERSION', '8.x-2.3');
+define('AUTH0_MODULE_VERSION', '8.x-2.4');
 
 /**
  * Replace a form with the lock widget.


### PR DESCRIPTION
**Changed**

- Remove resend verfication email button from the email verification template [\#160](https://github.com/auth0/auth0-drupal/pull/160) ([stevehobbsdev](https://github.com/stevehobbsdev))
